### PR TITLE
Bump violet-js version to 1.0.2 which changes axios from a dependency to a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/node": "18.14.6",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",
-    "@violetio/violet-js": "1.0.1",
+    "@violetio/violet-js": "1.0.2",
     "axios": "^1.3.4",
     "camelcase-keys": "8.0.2",
     "classnames": "^2.3.2",


### PR DESCRIPTION
We are changing axios to be a peerDependency so that users of the library can update axios versions for security on their own